### PR TITLE
Handle missing natural inflow data

### DIFF
--- a/src/process_generators_storages.jl
+++ b/src/process_generators_storages.jl
@@ -77,8 +77,11 @@ function process_generators_storages!(
 
         end
 
-        raw_inflows =
-            readsingleband(plexosfile["/data/ST/interval/storages/Natural Inflow"])
+        if haskey(plexosfile, "/data/ST/interval/storages/Natural Inflow") 
+            raw_inflows = readsingleband(plexosfile["/data/ST/interval/storages/Natural Inflow"])
+        else
+            raw_inflows = zeros(size(raw_chargeefficiency))
+        end
         raw_decayrate =
             readsingleband(plexosfile["/data/ST/interval/storages/x"]) ./ 100
         raw_carryoverefficiency =


### PR DESCRIPTION
meant to do this a couple weeks back but now have a full set of cases to translate...

Purpose here is to have handling for if natural_inflow property is missing to fill it with 0's instead of throwing an error. Just opening PR for now - will clean up soon.